### PR TITLE
Added ability to specify commit author.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3066,9 +3066,9 @@
       "dev": true
     },
     "github-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.0.0.tgz",
-      "integrity": "sha1-KDL5jQ06g/FIXi2zLJJZ5LnECnU=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.2.0.tgz",
+      "integrity": "sha512-AsO1LxrCi07qUdCqOExyAgvzvnN8WFV6BQ+LJzzmgzPJQ69+AzTCnt9bc61T8rE/LLj81qOGd7sLJeKbu0lEyA==",
       "requires": {
         "axios": "^0.15.2",
         "debug": "^2.2.0",
@@ -3582,9 +3582,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.23.0",
-    "github-api": "^3.0.0",
+    "github-api": "^3.2.0",
     "micro": "^9.0.2"
   },
   "engines": {

--- a/src/PullRequest.js
+++ b/src/PullRequest.js
@@ -34,10 +34,15 @@ module.exports = class PullRequest {
         files,
         commitMessage = null,
         titlePullRequest = null,
-        descriptionPullRequest = null
+        descriptionPullRequest = null,
+        commitAuthor = {
+            'name': 'canada-bot',
+            'email': 'canada.pr.bot@gmail.com'
+        }
     ) {
 
         this.commitMessage = `🤖 ${commitMessage || 'Anonymous Commit'}`;
+        this.commitAuthor = commitAuthor;
         this.titlePullRequest = titlePullRequest;
         this.descriptionPullRequest = descriptionPullRequest;
         this.files = files;
@@ -238,8 +243,9 @@ module.exports = class PullRequest {
     }
 
     _commitChanges() {
-
-        return this.fork.commit(this.currentCommitSHA, this.currentTreeSHA, this.commitMessage)
+        return this.fork.commit(this.currentCommitSHA, this.currentTreeSHA, this.commitMessage, {
+            author: this.commitAuthor
+        })
             .then((commit) => {
                 this.currentCommitSHA = commit.data.sha;
             });

--- a/src/handlers/micro.js
+++ b/src/handlers/micro.js
@@ -5,8 +5,18 @@ const cors = require("../cors")();
 const handler = async (req, res) => {
     try {
         const body = await json(req);
+
+        // Set the commit author if requested.
+        let author = {
+            name: 'canada-bot',
+            email: 'canada.pr.bot@gmail.com',
+        };
+        if (body.author) {
+            author = body.author
+        }
+
         const pr = new PR(body.user, body.repo, body.branch, body.token);
-        pr.configure(body.files, body.commit, body.title, body.description);
+        pr.configure(body.files, body.commit, body.title, body.description, author);
         const { data } = await pr.send();
         return data;
     } catch (err) {


### PR DESCRIPTION
You can now specify the commit author when using PRBot. Run the following to see how it works:
``` bash
curl -X POST \
  http://localhost:3000 \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
    "user": "canada-bot",
    "repo": "arepo",
    "title": "Test request 5",
    "description": "Adding a new static file",
    "commit": "Committed by a person",
    "author": {
    	"name": "j-rewerts",
    	"email": "jared.rewerts@edmonton.ca"
    },
    "files": [
        {
            "path": "README.md",
            "content": "stuff:"
        }
    ]
}'
```

This assumes you're running PRBot locally on port 3000. 
This will create a PR where the commit author is j-rewerts, even though PRBot is doing all of the work. Check out an example PR [here](https://github.com/canada-bot/arepo/pull/19/commits). Note the author of the commit.